### PR TITLE
feat: 可面板配置的判断权重

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -46,5 +46,35 @@
     "type": "list",
     "default": [],
     "hint": "允许心流回复的群聊sid列表，/sid获取"
+  },
+  "judge_relevance": {
+    "description": "判断权重的内容相关度",
+    "type": "float",
+    "default": 0.25,
+    "hint": "针对判断权重的内容相关度设置，默认25%"
+  },
+  "judge_willingness": {
+    "description": "判断权重的回复意愿",
+    "type": "float",
+    "default": 0.2,
+    "hint": "针对判断权重的回复意愿设置，默认20%"
+  },
+  "judge_social": {
+    "description": "判断权重的社交适宜性",
+    "type": "float",
+    "default": 0.2,
+    "hint": "针对判断权重的社交适宜性设置，默认20%"
+  },
+  "judge_timing": {
+    "description": "判断权重的时机相关性",
+    "type": "float",
+    "default": 0.15,
+    "hint": "针对判断权重的时机相关性设置，默认15%"
+  },
+  "judge_continuity": {
+    "description": "判断权重的对话连贯性",
+    "type": "float",
+    "default": 0.2,
+    "hint": "针对判断权重的对话连贯性设置，默认20%"
   }
 }

--- a/main.py
+++ b/main.py
@@ -64,12 +64,19 @@ class HeartflowPlugin(star.Star):
 
         # 判断权重配置
         self.weights = {
-            "relevance": 0.25,
-            "willingness": 0.2,
-            "social": 0.2,
-            "timing": 0.15,
-            "continuity": 0.2  # 新增：与上次回复的连贯性
+            "relevance": self.config.get("judge_relevance", 0.25),
+            "willingness": self.config.get("judge_willingness", 0.2),
+            "social": self.config.get("judge_social", 0.2),
+            "timing": self.config.get("judge_timing", 0.15),
+            "continuity": self.config.get("judge_continuity", 0.2)
         }
+        # 检查权重和
+        weight_sum = sum(self.weights.values())
+        if abs(weight_sum - 1.0) > 1e-6:
+            logger.warning(f"判断权重和不为1，当前和为{weight_sum}")
+            # 进行归一化处理
+            self.weights = {k: v / weight_sum for k, v in self.weights.items()}
+            logger.info(f"判断权重和已归一化，当前配置为: {self.weights}")
 
         logger.info("心流插件已初始化")
 


### PR DESCRIPTION
## 我的修改

将判断权重系数改为Web页面可配置，当和大于1时报Warning并自动Normalize到和为1.

## 变量命名

暂时用的"判断xx"的命名，另外在`_conf_schema.json`中的`description`和`hint`可能都需要做一些改善。

## 注意

我没有修改`metadata.yml`中的`version`，这可能应该由mantainer @advent259141 决定