### PR TITLE
fix: 合并判断模型上下文数量配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Gemma 27b，可在Google Aistudio获取密钥后使用，每天免费14400次，
 - `reply_threshold`：回复阈值 (0-1，默认0.6)
 - `energy_decay_rate`：精力衰减速度 (默认0.1)
 - `energy_recovery_rate`：精力恢复速度 (默认0.02)
-- `context_messages_count`：上下文消息数量 (默认5)
+- `judge_context_count`：判断模型上下文条数，用于控制传给小判断模型的最近群聊历史条数 (默认10)
 
 ### 白名单配置
 - `whitelist_enabled`：启用群聊白名单 (默认false)

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -30,12 +30,6 @@
     "default": 0.02,
     "hint": "每次不回复时精力恢复的幅度"
   },
-  "context_messages_count": {
-    "description": "上下文消息数量",
-    "type": "int",
-    "default": 5,
-    "hint": "判断时考虑的最近消息数量"
-  },
   "whitelist_enabled": {
     "description": "启用群聊白名单",
     "type": "bool",
@@ -91,10 +85,10 @@
     "hint": "当小模型返回无效JSON时的最大重试次数，设为0时不重试，建议1-5次"
   },
   "judge_context_count": {
-    "description": "传入判断模型的上下文条数",
+    "description": "判断模型上下文条数",
     "type": "int",
     "default": 10,
-    "hint": "传给判断模型的对话历史条数，独立于context_messages_count，建议设置更大的值以提升判断质量"
+    "hint": "判断是否主动回复时，传给小判断模型的最近群聊历史条数。值越大，看到的上下文越多，但也会增加 token 消耗和噪声。"
   },
   "min_reply_interval_seconds": {
     "description": "最短回复间隔（秒）",

--- a/main.py
+++ b/main.py
@@ -104,10 +104,9 @@ class HeartflowPlugin(star.Star):
         self.reply_threshold = self.config.get("reply_threshold", 0.6)
         self.energy_decay_rate = self.config.get("energy_decay_rate", 0.1)
         self.energy_recovery_rate = self.config.get("energy_recovery_rate", 0.02)
-        self.judge_context_count = max(
-            0,
-            int(self.config.get("judge_context_count", self.config.get("context_messages_count", 10)) or 0),
-        )
+        judge_count = int(self.config.get("judge_context_count", 10) or 0)
+        legacy_count = int(self.config.get("context_messages_count", 0) or 0)
+        self.judge_context_count = max(0, judge_count, legacy_count)
         self.min_reply_interval = self.config.get("min_reply_interval_seconds", 0)
         self.whitelist_enabled = self.config.get("whitelist_enabled", False)
         self.chat_whitelist = self.config.get("chat_whitelist", [])

--- a/main.py
+++ b/main.py
@@ -104,8 +104,10 @@ class HeartflowPlugin(star.Star):
         self.reply_threshold = self.config.get("reply_threshold", 0.6)
         self.energy_decay_rate = self.config.get("energy_decay_rate", 0.1)
         self.energy_recovery_rate = self.config.get("energy_recovery_rate", 0.02)
-        self.context_messages_count = self.config.get("context_messages_count", 5)
-        self.judge_context_count = self.config.get("judge_context_count", self.context_messages_count)
+        self.judge_context_count = max(
+            0,
+            int(self.config.get("judge_context_count", self.config.get("context_messages_count", 10)) or 0),
+        )
         self.min_reply_interval = self.config.get("min_reply_interval_seconds", 0)
         self.whitelist_enabled = self.config.get("whitelist_enabled", False)
         self.chat_whitelist = self.config.get("chat_whitelist", [])
@@ -116,7 +118,7 @@ class HeartflowPlugin(star.Star):
         # 原始群聊消息缓冲区：{unified_msg_origin: deque[RawMessage]}
         # 记录所有群聊原始消息（无论是否触发 LLM），用于判断上下文
         self._raw_msg_buffer: Dict[str, deque] = {}
-        self._raw_msg_buffer_size = max(self.context_messages_count, self.judge_context_count) * 4  # 缓冲区保留更多条以备用
+        self._raw_msg_buffer_size = max(self.judge_context_count * 4, 20)  # 缓冲区保留更多条以备用
 
         # 系统提示词缓存：{conversation_id: {"original": str, "summarized": str, "persona_id": str}}
         self.system_prompt_cache: Dict[str, Dict[str, str]] = {}
@@ -288,7 +290,7 @@ class HeartflowPlugin(star.Star):
 ## 群聊基本信息
 {chat_context}
 
-## 最近{self.context_messages_count}条对话历史
+## 最近{self.judge_context_count}条对话历史
 {recent_messages}
 
 ## 上次机器人回复
@@ -349,9 +351,6 @@ class HeartflowPlugin(star.Star):
             complete_judge_prompt += "\n\n**重要提醒：你必须严格按照JSON格式返回结果，不要包含任何其他内容！请不要进行对话，只返回JSON！**\n\n"
             complete_judge_prompt += judge_prompt
 
-            # 提前计算对话历史上下文（循环外只算一次）
-            recent_contexts = self._get_recent_contexts(event)
-
             # 重试机制：使用配置的重试次数
             max_retries = self.judge_max_retries + 1
             if self.judge_max_retries == 0:
@@ -361,7 +360,7 @@ class HeartflowPlugin(star.Star):
                 try:
                     llm_response = await judge_provider.text_chat(
                         prompt=complete_judge_prompt,
-                        contexts=recent_contexts,
+                        contexts=[],
                         image_urls=[],
                     )
 
@@ -591,24 +590,6 @@ class HeartflowPlugin(star.Star):
 
         return int((time.time() - chat_state.last_reply_time) / 60)
 
-    def _get_recent_contexts(self, event: AstrMessageEvent) -> list:
-        """从原始消息缓冲区获取最近对话上下文（用于传递给小参数模型）。
-
-        使用本地缓冲区而非 conversation_manager，以便包含所有群聊消息，
-        而不仅仅是触发过 LLM 的消息。
-        """
-        msgs = self._get_raw_buffer(event.unified_msg_origin)
-        # 排除当前这条消息（已被 _record_raw_message 写入），取之前的若干条
-        if msgs and msgs[-1].content == event.message_str:
-            msgs = msgs[:-1]
-        recent = msgs[-self.context_messages_count:] if len(msgs) > self.context_messages_count else msgs
-
-        contexts = []
-        for m in recent:
-            role = "assistant" if m.is_bot else "user"
-            contexts.append({"role": role, "content": m.content})
-        return contexts
-
     def _get_recent_messages(self, event: AstrMessageEvent) -> str:
         """从原始消息缓冲区获取最近的消息历史（用于小参数模型判断）。
 
@@ -618,7 +599,10 @@ class HeartflowPlugin(star.Star):
         # 排除当前这条消息（已被 _record_raw_message 写入），取之前的若干条
         if msgs and msgs[-1].content == event.message_str:
             msgs = msgs[:-1]
-        recent = msgs[-self.context_messages_count:] if len(msgs) > self.context_messages_count else msgs
+        count = max(0, int(self.judge_context_count or 0))
+        if count <= 0:
+            return "暂无对话历史"
+        recent = msgs[-count:] if len(msgs) > count else msgs
 
         if not recent:
             return "暂无对话历史"


### PR DESCRIPTION
## 修改内容

修复 `judge_context_count` 配置未按文案生效的问题，并合并重复的上下文数量配置。

主要改动：

1. 删除插件配置 UI 中重复的 `context_messages_count`。
2. 统一使用 `judge_context_count` 控制判断模型参考的最近聊天记录数量。
3. 停止同时向判断模型传入 prompt 历史和 Provider contexts，避免重复上下文。
4. 保留 prompt 中带发送者名称的群聊历史格式。
5. 兼容旧配置中的 `context_messages_count`，取 `judge_context_count` 和旧值的最大值，避免老用户升级后历史窗口变小。
6. 修复 `judge_context_count <= 0` 时可能误取全量历史的问题。
7. 为原始消息 buffer 设置最小容量，避免历史缓存失效。
8. 同步更新 README 配置说明。

## 问题原因

旧版本中，`judge_context_count` 在配置页面显示为“传入判断模型的上下文条数”，但实际判断历史数量主要由 `context_messages_count` 控制，导致配置项文案和实际行为不一致。

同时，判断模型调用时已经把最近聊天记录写入 prompt，又额外通过 `contexts` 传入历史。AstrBot Provider 会将 prompt 追加到 contexts，因此存在重复上下文风险。

## 兼容性

保留对旧配置 `context_messages_count` 的临时兼容读取，并取新旧两个配置值的最大值，避免已有用户升级后判断模型参考的历史条数减少。

## 测试情况

- 已确认 `judge_context_count` 正常控制 prompt 中的最近聊天记录数量。
- 已确认 `judge_context_count = 0` 时不会误取全量历史。
- 已确认判断模型调用时 `contexts` 为空，不再重复传入上下文。
- 已确认 README 中配置项已同步更新。